### PR TITLE
el ftp del ccc.uba no está andando.

### DIFF
--- a/dockerfiles/uba_docker_setting
+++ b/dockerfiles/uba_docker_setting
@@ -1,2 +1,1 @@
 COPY dockerfiles/apt.conf /etc/apt/apt.conf
-RUN cat /etc/apt/sources.list | grep 'deb.debian.org' | sed 's+deb.debian.org+ftp.ccc.uba.ar/pub/linux/debian+' > /etc/apt/sources.list.d/uba.list


### PR DESCRIPTION
Y además, no parece hacer falta