### PR TITLE
update de django

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==2.1.9
+Django==2.1.10
 django-extensions
 bs4
 coloredlogs


### PR DESCRIPTION
github nos avisa que según CVE-2019-12781, django 2.1.9 tiene vulnerabilidad moderada.
Y bueno, pasarnos a 2.1.10 es gratis.